### PR TITLE
docs: added scope for audit brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The protocol will be deployed as a native application on the upcoming Sonic Netw
 - **Mint and use asset as collateral**: Users will be able to mint cTokens and use them as collateral for borrowing in a single function call for better UX.
 - **block.timestamp vs block.number**: The protocol will use `block.timestamp` for all interest rate calculations, instead of `block.number`.
 - **Reward Distribution**: Instead of the `Comptroller` updating & distributing rewards, a separate contract `RewardDistributor` (WIP) will be responsible for distributing rewards.
-- **Price Oracle**: Via an Upgradable `PriceOracleAggregator.sol`, the protocol has a priority list of price feeds such as Pyth and Band to fetch price data.
+- **Price Oracle**: Via an Upgradable `PriceOracleAggregator.sol`, the protocol has a priority list of price feeds such as Pyth and API3 to fetch price data.
+- **Protocol Seize Share**: Make `protocolSeizeShare` a modifiable variable by the admin.
+- **Sweep**: Add `sweepToken` and `sweepNative` functions to allow the admin to sweep any ERC-20 tokens or $S (except the underlying asset) from the `cSonic` or `cErc20` contracts to the admin address
+
+More details can be found in the [audit brief](audit/brief.md).
 
 ## Usage
 

--- a/audit/brief.md
+++ b/audit/brief.md
@@ -6,6 +6,9 @@ Mach Finance is a Compound v2 fork with few changes highlighted here:
 3. `block.timestamp` instead of `block.number` when modelling interest rates
 4. Extract out accrual & distribution that was previously in `Comptroller` to external `Distributor` contract
 5. `mintAsCollateral` function that mints & enables the asset as collateral
+6. Make `protocolSeizeShare` modifiable by admin
+7. `sweepToken` function that only allows admin to sweep any ERC-20 tokens from cSonic contract
+8. `sweepNative` function that only allows admin to sweep any native assets from cErc20 contract
 
 # Files to review
 - `src/Oracles/API3/*.sol`
@@ -132,3 +135,15 @@ Case 3:
 - 200 USDC in liquidity calculations as collateral
 
 Check possible front-running attacks on `mintAsCollateral`, what are the possible implications?
+
+## `protocolSeizeShare` is a modifiable variable by the admin
+
+`protocolSeizeShare` is a function that allows the admin to set the percentage of the protocol's share of the seized collateral.
+
+## `sweepToken` function that only allows admin to sweep any ERC-20 tokens from cSonic contract to admin address
+
+Ensure ERC20 tokens are not stuck in the `cSonic` contract. 
+
+## `sweepNative` function that only allows admin to sweep any native assets from cErc20 contract to admin address
+
+Ensure $S is not stuck in the respective `cErc20` contract.


### PR DESCRIPTION
- Added additional scope for audit brief
- `protocolSeizeShare`
- `sweepToken` / `sweepNative`