### PR TITLE
feat: validate listed markets for supply / borrow caps

### DIFF
--- a/src/Comptroller.sol
+++ b/src/Comptroller.sol
@@ -1037,6 +1037,8 @@ contract Comptroller is ComptrollerV2Storage, ComptrollerInterface, ComptrollerE
         require(numMarkets != 0 && numMarkets == numBorrowCaps, "invalid input");
 
         for (uint256 i = 0; i < numMarkets; i++) {
+            // Check cTokens[i] is supported cToken
+            require(markets[address(cTokens[i])].isListed, "market must be listed");
             borrowCaps[address(cTokens[i])] = newBorrowCaps[i];
             emit NewBorrowCap(cTokens[i], newBorrowCaps[i]);
         }
@@ -1060,6 +1062,8 @@ contract Comptroller is ComptrollerV2Storage, ComptrollerInterface, ComptrollerE
         require(numMarkets != 0 && numMarkets == numSupplyCaps, "invalid input");
 
         for (uint256 i = 0; i < numMarkets; i++) {
+            // Check cTokens[i] is supported cToken
+            require(markets[address(cTokens[i])].isListed, "market must be listed");
             supplyCaps[address(cTokens[i])] = newSupplyCaps[i];
             emit NewSupplyCap(cTokens[i], newSupplyCaps[i]);
         }

--- a/test/CToken.t.sol
+++ b/test/CToken.t.sol
@@ -47,6 +47,36 @@ contract CTokenTest is BaseTest {
         assertEq(address(admin).balance, 100 ether);
     }
 
+    function testRevert_setNonCTokenSupplyCap() public {
+        vm.startPrank(admin);
+        address nonCToken = makeAddr("nonCToken");
+
+        CToken[] memory cTokens = new CToken[](1);
+        cTokens[0] = CToken(address(nonCToken));
+
+        uint256[] memory supplyCaps = new uint256[](1);
+        supplyCaps[0] = 100 ether;
+
+        vm.expectRevert("market must be listed");
+        comptroller._setMarketSupplyCaps(cTokens, supplyCaps);
+        vm.stopPrank();
+    }
+
+    function testRevert_setNonCTokenBorrowCap() public {
+        vm.startPrank(admin);
+        address nonCToken = makeAddr("nonCToken");
+
+        CToken[] memory cTokens = new CToken[](1);
+        cTokens[0] = CToken(address(nonCToken));
+
+        uint256[] memory newBorrowCaps = new uint256[](1);
+        newBorrowCaps[0] = 100 ether;
+
+        vm.expectRevert("market must be listed");
+        comptroller._setMarketBorrowCaps(cTokens, newBorrowCaps);
+        vm.stopPrank();
+    }
+
     function test_mint_hitSupplyCap() public {
         deal(address(wbtc), admin, 1000 ether);
         deal(admin, 1e9 ether);


### PR DESCRIPTION
Fixes Sherlock "Lack of Validation for Listed Markets in `_setMarketSupplyCaps`"
- https://github.com/sherlock-audit/2024-12-mach-finance-judging/issues/63
- https://github.com/sherlock-audit/2024-12-mach-finance-judging/issues/64