### PR TITLE
feat: staleness checks are modifiable in API3 oracle

### DIFF
--- a/src/Oracles/API3/API3Oracle.sol
+++ b/src/Oracles/API3/API3Oracle.sol
@@ -14,8 +14,8 @@ contract API3Oracle is IOracleSource, Ownable2Step {
 
     event UnderlyingTokenApi3ProxyAddressSet(address indexed token, address api3ProxyAddress);
     event StalePriceThresholdSet(uint256 indexed stalePriceThreshold);
-    // @notice Stale price threshold in seconds
 
+    // @notice Stale price threshold in seconds
     uint256 public stalePriceThreshold;
     // @notice Mapping between underlying token and API3 proxy address
     mapping(address => address) public tokenToApi3ProxyAddress;
@@ -32,8 +32,8 @@ contract API3Oracle is IOracleSource, Ownable2Step {
             _setApi3ProxyAddress(_underlyingTokens[i], _api3ProxyAddresses[i]);
         }
 
-        // Currently, API3 provides 24 hour heartbeat, so set stale price threshold to 24 hours
-        stalePriceThreshold = 24 hours;
+        // Currently, API3 provides 24 hour heartbeat, so set default stale price threshold to 24 hours
+        _setStalePriceThreshold(24 hours);
     }
 
     /**
@@ -139,6 +139,14 @@ contract API3Oracle is IOracleSource, Ownable2Step {
      * @param _stalePriceThreshold The new stale price threshold in seconds
      */
     function setStalePriceThreshold(uint256 _stalePriceThreshold) external onlyOwner {
+        _setStalePriceThreshold(_stalePriceThreshold);
+    }
+
+    /**
+     * @notice Internal function to set stale price threshold
+     * @param _stalePriceThreshold The new stale price threshold in seconds
+     */
+    function _setStalePriceThreshold(uint256 _stalePriceThreshold) internal {
         require(_stalePriceThreshold > 0, "API3Oracle: Stale price threshold must be greater than 0");
         stalePriceThreshold = _stalePriceThreshold;
         emit StalePriceThresholdSet(_stalePriceThreshold);

--- a/src/Oracles/Pyth/PythOracle.sol
+++ b/src/Oracles/Pyth/PythOracle.sol
@@ -43,8 +43,7 @@ contract PythOracle is IOracleSource, Ownable2Step {
             _setPriceFeedId(_underlyingTokens[i], _priceFeedIds[i]);
         }
 
-        require(_stalePriceThreshold > 0, "PythOracle: Stale price threshold must be greater than 0");
-        stalePriceThreshold = _stalePriceThreshold;
+        _setStalePriceThreshold(_stalePriceThreshold);
     }
 
     function _setPriceFeedId(address underlyingToken, bytes32 priceFeedId) internal {
@@ -136,6 +135,10 @@ contract PythOracle is IOracleSource, Ownable2Step {
      * @param _stalePriceThreshold The new stale price threshold in seconds
      */
     function setStalePriceThreshold(uint256 _stalePriceThreshold) external onlyOwner {
+        _setStalePriceThreshold(_stalePriceThreshold);
+    }
+
+    function _setStalePriceThreshold(uint256 _stalePriceThreshold) internal {
         require(_stalePriceThreshold > 0, "PythOracle: Stale price threshold must be greater than 0");
         stalePriceThreshold = _stalePriceThreshold;
         emit StalePriceThresholdSet(_stalePriceThreshold);

--- a/src/Oracles/Pyth/PythOracle.sol
+++ b/src/Oracles/Pyth/PythOracle.sol
@@ -17,10 +17,13 @@ contract PythOracle is IOracleSource, Ownable2Step {
     address public constant NATIVE_ASSET = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     event UnderlyingTokenPriceFeedSet(address indexed token, bytes32 priceFeedId);
+    event StalePriceThresholdSet(uint256 indexed stalePriceThreshold);
 
     IPyth public immutable pyth;
 
+    // @notice Stale price threshold in seconds
     uint256 public stalePriceThreshold;
+    // @notice Mapping between underlying token and Pyth price feed id
     mapping(address => bytes32) public priceFeedIds;
 
     constructor(
@@ -135,5 +138,6 @@ contract PythOracle is IOracleSource, Ownable2Step {
     function setStalePriceThreshold(uint256 _stalePriceThreshold) external onlyOwner {
         require(_stalePriceThreshold > 0, "PythOracle: Stale price threshold must be greater than 0");
         stalePriceThreshold = _stalePriceThreshold;
+        emit StalePriceThresholdSet(_stalePriceThreshold);
     }
 }

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -25,6 +25,7 @@ interface IEvents {
     event UnderlyingSymbolSet(address indexed token, string symbol);
     event UnderlyingTokenPriceFeedSet(address indexed token, bytes32 priceFeedId);
     event UnderlyingTokenApi3ProxyAddressSet(address indexed token, address api3ProxyAddress);
+    event StalePriceThresholdSet(uint256 indexed stalePriceThreshold);
 }
 
 contract BaseTest is Test, IError, IEvents {

--- a/test/Oracle.t.sol
+++ b/test/Oracle.t.sol
@@ -605,6 +605,50 @@ contract OracleTest is BaseTest {
         api3Oracle.bulkSetApi3ProxyAddresses(tokens, api3ProxyAddresses);
     }
 
+    function test_pythOracle_setStalePriceThreshold(uint256 newStalePriceThreshold) public {
+        vm.assume(newStalePriceThreshold > 0);
+
+        vm.prank(admin);
+        pythOracle.setStalePriceThreshold(newStalePriceThreshold);
+        assertEq(pythOracle.stalePriceThreshold(), newStalePriceThreshold);
+    }
+
+    function test_api3Oracle_setStalePriceThreshold(uint256 newStalePriceThreshold) public {
+        vm.assume(newStalePriceThreshold > 0);
+
+        vm.prank(admin);
+        api3Oracle.setStalePriceThreshold(newStalePriceThreshold);
+        assertEq(api3Oracle.stalePriceThreshold(), newStalePriceThreshold);
+    }
+
+    function testRevert_pythOracle_whenSetInvalidStalePriceThreshold() public {
+        vm.prank(admin);
+        vm.expectRevert("PythOracle: Stale price threshold must be greater than 0");
+        pythOracle.setStalePriceThreshold(0);
+    }
+
+    function testRevert_api3Oracle_whenSetInvalidStalePriceThreshold() public {
+        vm.prank(admin);
+        vm.expectRevert("API3Oracle: Stale price threshold must be greater than 0");
+        api3Oracle.setStalePriceThreshold(0);
+    }
+
+    function testRevert_pythOracle_whenNonOwnerSetsStalePriceThreshold(address user) public {
+        vm.assume(user != admin);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user));
+        pythOracle.setStalePriceThreshold(1 days);
+    }
+
+    function testRevert_api3Oracle_whenNonOwnerSetsStalePriceThreshold(address user) public {
+        vm.assume(user != admin);
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(OwnableUnauthorizedAccount.selector, user));
+        api3Oracle.setStalePriceThreshold(1 days);
+    }
+
     function testRevert_pythOracle_whenNonAdminSetsPriceFeed(address user) public {
         vm.assume(user != admin);
 


### PR DESCRIPTION
Sherlock Audit Fix Review:
- Ensure API3 has modifiable staleness period, `onlyOwner`
- Emit events for `API3Oracle` & `PythOracle`